### PR TITLE
Decoding optional values

### DIFF
--- a/Sources/URLQueryItemsDecoder.swift
+++ b/Sources/URLQueryItemsDecoder.swift
@@ -93,6 +93,10 @@ extension URLQueryItemsDecoder {
             return try container.first(where: { $0.name == key.stringValue })
                 .unwrapOrThrow(error: decoder.notFound(key: key))
         }
+        
+        private func isNill(forKey key: CodingKey) throws -> Bool {
+            return container.first(where: { $0.name == key.stringValue }) == nil
+        }
 
         func _decode<T: Decodable & LosslessStringConvertible>(_ type: T.Type, forKey key: Key) throws -> T {
             let value = try find(forKey: key)
@@ -108,7 +112,7 @@ extension URLQueryItemsDecoder {
             return try decoder.unbox(value, as: T.self)
         }
 
-        func decodeNil(forKey key: Key) throws -> Bool { throw decoder.notFound(key: key) }
+        func decodeNil(forKey key: Key) throws -> Bool { return try isNill(forKey: key) }
         func decode(_ type: Bool.Type, forKey key: Key) throws -> Bool { return try _decode(type, forKey: key) }
         func decode(_ type: Int.Type, forKey key: Key) throws -> Int { return try _decode(type, forKey: key) }
         func decode(_ type: Int8.Type, forKey key: Key) throws -> Int8 { return try _decode(type, forKey: key) }

--- a/Tests/URLQueryItemsDecoderTests.swift
+++ b/Tests/URLQueryItemsDecoderTests.swift
@@ -38,5 +38,39 @@ class URLQueryItemsDecoderTests: XCTestCase {
         XCTAssertEqual(parameter.string, params[0].value)
         XCTAssertEqual(parameter.int.description, params[1].value)
         XCTAssertEqual(parameter.double.description, params[2].value)
+        
+    }
+    
+    func testDecodeOptionalParameter() throws {
+        struct Parameter: Codable {
+            let string: String?
+            let int: Int?
+            let double: Double?
+        }
+        let params: [URLQueryItem] = [
+            URLQueryItem(name: "string", value: "abc"),
+            URLQueryItem(name: "int", value: "123"),
+            URLQueryItem(name: "double", value: Double.pi.description)
+        ]
+        let parameter = try decoder.decode(Parameter.self, from: params)
+        
+        XCTAssertEqual(parameter.string, params[0].value)
+        XCTAssertEqual(parameter.int?.description, params[1].value)
+        XCTAssertEqual(parameter.double?.description, params[2].value)
+    }
+    
+    func testDecodeEmptyOptionalParameter() throws {
+        struct Parameter: Codable {
+            let string: String?
+            let int: Int?
+            let double: Double?
+        }
+        let params: [URLQueryItem] = [
+        ]
+        let parameter = try decoder.decode(Parameter.self, from: params)
+        
+        XCTAssertEqual(parameter.string, nil)
+        XCTAssertEqual(parameter.int, nil)
+        XCTAssertEqual(parameter.double, nil)
     }
 }


### PR DESCRIPTION
I think this will solve the issue #5.

The url param decoder was always throwing an exception if the query item existed for a key that represented an optional property. 

I have executed the tests and all seems working pretty well. 