### PR TITLE
Remove .h and .m files from source_files

### DIFF
--- a/MoreCodable.podspec
+++ b/MoreCodable.podspec
@@ -21,6 +21,5 @@ It contains DictionaryEncoder/Decoder, URLQueryItemsEncoder/Decoder, ObjectMerge
 
   s.source_files = 'Sources/**/*.{swift,h,m}'
   
-  s.public_header_files = 'Sources/**/*.h'
   s.frameworks = 'Foundation'
 end

--- a/MoreCodable.podspec
+++ b/MoreCodable.podspec
@@ -19,7 +19,8 @@ It contains DictionaryEncoder/Decoder, URLQueryItemsEncoder/Decoder, ObjectMerge
   s.watchos.deployment_target = '2.0'
   s.tvos.deployment_target = '9.0'
 
-  s.source_files = 'Sources/**/*.{swift,h,m}'
+  s.source_files = 'Sources/**/*.swift'
+  s.public_header_files = 'Sources/**/*.h'
   
   s.frameworks = 'Foundation'
 end


### PR DESCRIPTION
As a result umbrella header doesn't include `MoreCodable.h` and my project is able to build.

I'm unsure if it's right thing to do in general, but works for me. I hope someone with more experience with podspecs can pick this up.