### PR TITLE
Fix for DecodingError "Expected to decode Double but found Int instead."

### DIFF
--- a/Sources/InternalFunction.swift
+++ b/Sources/InternalFunction.swift
@@ -15,6 +15,12 @@ public enum MoreCodableError: Error {
 }
 
 func castOrThrow<T>(_ resultType: T.Type, _ object: Any, error: Error = MoreCodableError.cast) throws -> T {
+    /// Int literals cannot be cast as a Double using `as?` so `Double(<Int>)` must be used instead.
+    if let intValue = object as? Int,
+       let result = Double(intValue) as? T {
+        return result
+    }
+    /// Most `Any` types can be converted using `as?` if they're a compatible type
     guard let returnValue = object as? T else {
         throw error
     }

--- a/Tests/DictionaryDecoderTests.swift
+++ b/Tests/DictionaryDecoderTests.swift
@@ -100,6 +100,15 @@ class DictionaryDecoderTests: XCTestCase {
         }
         XCTAssertEqual(try decoder.decode(Model.self, from: ["date": 13]), Model(date: date, optionalDate: nil))
     }
+
+    /// JSON has only one Number type, and allows "5" to be considered a Double, not just "5.0"
+    /// - seealso: https://www.json.org/img/number.png
+    func testNumberToDouble() throws {
+        struct Model: Codable, Equatable {
+            let double: Double?
+        }
+        XCTAssertEqual(try decoder.decode(Model.self, from: ["double": 5]), Model(double: 5))
+    }
 }
 
 #if os(Linux)


### PR DESCRIPTION
**Related Issue**
https://github.com/tattn/MoreCodable/issues/21

**Description**
Int literals cannot be cast as a Double using `as?` so `Double(<Int>)` must be used instead. 
JSON has only one Number type, and allows "5" to be considered a Double, not just "5.0"

However MoreCodable's DictionaryDecoder always decoded "3" as an Int so we would need a way to convert it to a Double to support JSON's flexible number formats.

**Testing**
I've included a new unit test that fails before this PR, and passes once the change is made to `func castOrThrow<T>()`

**References**
This railroad from json.org shows that `3` is totally valid as a JSON number

![railroad diagram](https://www.json.org/img/number.png)